### PR TITLE
Updates how results are cached and reduces the timeout on data requests

### DIFF
--- a/js/tides.js
+++ b/js/tides.js
@@ -178,6 +178,10 @@
         var x = (2 * Math.PI) / m.cycle * m.x;
         m.y = Math.sin(x) + 1;
         
+				// prepare the date of tide retrieval for display
+        var retrieved = new Date(tides.date * 1000);
+				var options = { year: 'numeric', month: 'short', day: 'numeric', hour: "2-digit", minute: "2-digit" };
+        
         var fillcolor = el.classList.contains('darkmode') ? '#fff' : '#555';
         
         // Put it all together, converting the x and y positions to proportions of the SVG dimensions
@@ -189,7 +193,7 @@
         output += '</svg>';
         output += '</div>';
         
-        output += '<div class="uri-tides-source">Source: <a href="https://tidesandcurrents.noaa.gov/stationhome.html?id=' + station + '" title="NOAA Center for Operational Oceanographic Producs and Services">NOAA/NOS/CO-OPS</a></div>';
+        output += '<div class="uri-tides-source">Source: <a href="https://tidesandcurrents.noaa.gov/stationhome.html?id=' + station + '" title="NOAA Center for Operational Oceanographic Producs and Services; tide data retrieved: ' + retrieved.toLocaleDateString("en-US", options) + '">NOAA/NOS/CO-OPS</a></div>';
         
         
         // Display

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -185,9 +185,9 @@ function _uri_tides_notify_administrator( $tides_data ) {
 	$expiry = (new DateTime('@' . $tides_data['expires_on']))->setTimezone(new DateTimeZone( $tz ));
 
 	$subject = 'URI Tides failed to update tide data';
-	$message = "The last time that tides data was refreshed successfully was on: " .  $date->format( 'Y-m-d\TH:i:s' );
+	$message = "The last time that tides data was refreshed successfully was on: " . $date->format( 'Y-m-d\TH:i:s' );
 	$message .= "\n\n";
-	$message .= "The site will try to refresh tides information on: " .  $expiry->format( 'Y-m-d\TH:i:s' );
+	$message .= "The site will try to refresh tides information on: " . $expiry->format( 'Y-m-d\TH:i:s' );
 		
 	return wp_mail($to, $subject, $message );
 }
@@ -199,6 +199,9 @@ function _uri_tides_load_cache() {
 	$tides_data = get_site_option( 'uri_tides_cache', FALSE);
 	if ( empty( $tides_data ) ) {
 		$tides_data = array();
+		// @todo: move these date setters to their own function.  they're similar in uri_tides_write_cache
+		$tides_data['date'] = strtotime('now');
+		$tides_data['expires_on'] = strtotime( '+'.get_site_option( 'uri_tides_recency', '5 minutes' ), strtotime('now') );
 	}
 	return $tides_data;
 }
@@ -228,7 +231,6 @@ function uri_tides_query_buoy() {
  */
 function _uri_tides_build_url( $q='temperature', $station='8454049' ) {
 	$base = 'https://tidesandcurrents.noaa.gov/api/datagetter?';
-	$base = 'https://ppkr.local/api/datagetter?';
 	$application = 'NOS.COOPS.TAC.' . ($q == 'temperature') ? 'PHYSOCEAN' : 'WL';
 	
 	if($q == 'temperature' ) {

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -159,7 +159,7 @@ function uri_tides_get_data() {
 			uri_tides_write_cache($tides_data, $expires_on);
 			
 			// notify the administrator of a problem
-			_uri_tides_notify_administrator( $tides_data );
+			// _uri_tides_notify_administrator( $tides_data );
 			
 		}
 		
@@ -176,6 +176,7 @@ function uri_tides_get_data() {
  * @return bool
  */
 function _uri_tides_notify_administrator( $tides_data ) {
+	// @todo: identify which site is sending the error
 	$to = get_option('admin_email');
 	if( empty ( $admin_email ) ) {
 		$to = 'jpennypacker@uri.edu';
@@ -315,12 +316,7 @@ function _uri_tides_query( $url ) {
 
 		// still here?  Then the content from API has been rejected
 		// @todo: log sensible debugging information
-		
-		// echo 'There was an error with the URI Tides Plugin. ';
-		// likely condition
-// 		if ( wp_remote_retrieve_response_code($response) != '200' ) {
-// 			echo 'The response code was not 200.';
-// 		}
+
 		return FALSE;
 
 }

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -295,6 +295,7 @@ function _uri_tides_query( $url ) {
 	
 	
 	$response = wp_safe_remote_get ( $url, $args );
+	
 
 	if( is_wp_error ($response) ) {
 		// there was an error making the API call
@@ -305,18 +306,26 @@ function _uri_tides_query( $url ) {
 	// still here?  good.  it means WP got an acceptable response.  Let's validate it.
 	
 	if ( isset( $response['body'] ) && !empty( $response['body'] ) && wp_remote_retrieve_response_code($response) == '200' ) {
+	
+		$data = json_decode ( wp_remote_retrieve_body ( $response ) );
+
+		// check that the response has a body and that it contains the properties that we're looking for
+		if( ( isset($data->metadata) || isset($data->predictions) ) ) {
+			// hooray, all is well!
+			return $data;
+		}
 		
-		// hooray, all is well!
-		return json_decode ( wp_remote_retrieve_body ( $response ) );
 
 	} else {
 
 		// still here?  Then the content from API has been rejected
-		echo 'There was an error with the URI Tides Plugin. ';
+		// @todo: log sensible debugging information
+		
+		// echo 'There was an error with the URI Tides Plugin. ';
 		// likely condition
-		if ( wp_remote_retrieve_response_code($response) != '200' ) {
-			echo 'The response code was not 200.';
-		}
+// 		if ( wp_remote_retrieve_response_code($response) != '200' ) {
+// 			echo 'The response code was not 200.';
+// 		}
 		return FALSE;
 	}
 }

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -304,19 +304,14 @@ function _uri_tides_query( $url ) {
 	} 
 	
 	// still here?  good.  it means WP got an acceptable response.  Let's validate it.
-	
 	if ( isset( $response['body'] ) && !empty( $response['body'] ) && wp_remote_retrieve_response_code($response) == '200' ) {
-	
 		$data = json_decode ( wp_remote_retrieve_body ( $response ) );
-
 		// check that the response has a body and that it contains the properties that we're looking for
 		if( ( isset($data->metadata) || isset($data->predictions) ) ) {
 			// hooray, all is well!
 			return $data;
 		}
-		
-
-	} else {
+	}
 
 		// still here?  Then the content from API has been rejected
 		// @todo: log sensible debugging information
@@ -327,6 +322,6 @@ function _uri_tides_query( $url ) {
 // 			echo 'The response code was not 200.';
 // 		}
 		return FALSE;
-	}
+
 }
 

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -153,7 +153,7 @@ function uri_tides_get_data() {
 			uri_tides_write_cache($tides_data);
 		} else {
 			// the cache is expired, but the fresh buoy response is invalid.
-			// extend the cache life span for an hour
+			// extend the cache's lifespan for an hour
 			$expires_on = strtotime( '+1 hour', strtotime('now') );
 			$tides_data = _uri_tides_load_cache();
 			uri_tides_write_cache($tides_data, $expires_on);
@@ -182,12 +182,13 @@ function _uri_tides_notify_administrator( $tides_data ) {
 	}
 	$tz = get_option('timezone_string');
 	$date = (new DateTime('@' . $tides_data['date']))->setTimezone(new DateTimeZone( $tz ));
-	$expiry = (new DateTime('@' . $tides_data['date']))->setTimezone(new DateTimeZone( $tz ));
+	$expiry = (new DateTime('@' . $tides_data['expires_on']))->setTimezone(new DateTimeZone( $tz ));
 
 	$subject = 'URI Tides failed to update tide data';
 	$message = "The last time that tides data was refreshed successfully was on: " .  $date->format( 'Y-m-d\TH:i:s' );
 	$message .= "\n\n";
 	$message .= "The site will try to refresh tides information on: " .  $expiry->format( 'Y-m-d\TH:i:s' );
+		
 	return wp_mail($to, $subject, $message );
 }
 
@@ -227,6 +228,7 @@ function uri_tides_query_buoy() {
  */
 function _uri_tides_build_url( $q='temperature', $station='8454049' ) {
 	$base = 'https://tidesandcurrents.noaa.gov/api/datagetter?';
+	$base = 'https://ppkr.local/api/datagetter?';
 	$application = 'NOS.COOPS.TAC.' . ($q == 'temperature') ? 'PHYSOCEAN' : 'WL';
 	
 	if($q == 'temperature' ) {

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -199,9 +199,8 @@ function _uri_tides_load_cache() {
 	$tides_data = get_site_option( 'uri_tides_cache', FALSE);
 	if ( empty( $tides_data ) ) {
 		$tides_data = array();
-		// @todo: move these date setters to their own function.  they're similar in uri_tides_write_cache
-		$tides_data['date'] = strtotime('now');
-		$tides_data['expires_on'] = strtotime( '+'.get_site_option( 'uri_tides_recency', '5 minutes' ), strtotime('now') );
+		$tides_data['date'] = strtotime('now -10 seconds');
+		$tides_data['expires_on'] = strtotime('now -10 seconds');
 	}
 	return $tides_data;
 }

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -295,6 +295,7 @@ function _uri_tides_query( $url ) {
 
 	if( is_wp_error ($response) ) {
 		// there was an error making the API call
+		// echo 'The error message is: ' . $response->get_error_message();
 		return FALSE;	
 	} 
 	
@@ -307,23 +308,12 @@ function _uri_tides_query( $url ) {
 
 	} else {
 
-		echo 'There was an error with the URI Tides Plugin';
-
-		// still here?  Then we have an error condition
-	
-		if ( is_wp_error ( $response ) ) {
-			$error_message = $response->get_error_message();
-			echo 'The error message is: ' . $error_message;
-			return FALSE;
-		}
+		// still here?  Then the content from API has been rejected
+		echo 'There was an error with the URI Tides Plugin. ';
+		// likely condition
 		if ( wp_remote_retrieve_response_code($response) != '200' ) {
 			echo 'The response code was not 200.';
-			echo $response;
-			return FALSE;
 		}
-
-		// still here?  the error condition is indeed unexpected
-		echo 'Empty response from server.';
 		return FALSE;
 	}
 }

--- a/uri-tides.php
+++ b/uri-tides.php
@@ -273,7 +273,6 @@ function uri_tides_write_cache( $tides_data, $expires_on='' ) {
  * @return bool
  */
 function uri_tides_is_expired( $date ) {
-	return TRUE;
 	return ( $date < strtotime('now') );
 }
 
@@ -293,6 +292,13 @@ function _uri_tides_query( $url ) {
 	
 	
 	$response = wp_safe_remote_get ( $url, $args );
+
+	if( is_wp_error ($response) ) {
+		// there was an error making the API call
+		return FALSE;	
+	} 
+	
+	// still here?  good.  it means WP got an acceptable response.  Let's validate it.
 	
 	if ( isset( $response['body'] ) && !empty( $response['body'] ) && wp_remote_retrieve_response_code($response) == '200' ) {
 		
@@ -301,20 +307,23 @@ function _uri_tides_query( $url ) {
 
 	} else {
 
+		echo 'There was an error with the URI Tides Plugin';
+
 		// still here?  Then we have an error condition
 	
 		if ( is_wp_error ( $response ) ) {
 			$error_message = $response->get_error_message();
-			echo 'There was an error with the URI Tides Plugin: ' . $error_message;
+			echo 'The error message is: ' . $error_message;
 			return FALSE;
 		}
 		if ( wp_remote_retrieve_response_code($response) != '200' ) {
+			echo 'The response code was not 200.';
 			echo $response;
 			return FALSE;
 		}
 
 		// still here?  the error condition is indeed unexpected
-		echo "Empty response from server?";
+		echo 'Empty response from server.';
 		return FALSE;
 	}
 }


### PR DESCRIPTION
Solves a problem where the tides plugin would cause page load time to balloon if the NOAA buoy is unavailable.